### PR TITLE
Fix CI: drop expired PAT, use default GITHUB_TOKEN

### DIFF
--- a/.github/check_fragments.sh
+++ b/.github/check_fragments.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Check whether changelog.d/ contains any fragments (ignoring .gitkeep).
+# Sets the GitHub Actions output "count" so later steps can skip if 0.
+set -euo pipefail
+
+FRAGMENTS=$(ls changelog.d/ | grep -cv .gitkeep || true)
+echo "count=$FRAGMENTS" >> "$GITHUB_OUTPUT"
+
+if [ "$FRAGMENTS" -eq 0 ]; then
+  echo "No changelog fragments found — skipping release."
+else
+  echo "Found $FRAGMENTS changelog fragment(s)."
+fi

--- a/.github/commit_and_push.sh
+++ b/.github/commit_and_push.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Stage release artifacts and push if anything changed.
+set -euo pipefail
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+git add package.json CHANGELOG.md changelog.d/
+
+if git diff --staged --quiet; then
+  echo "No changes to commit."
+  exit 0
+fi
+
+git commit -m "Release @policyengine/ui-kit"
+git push

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,18 +8,16 @@ jobs:
   release:
     name: Bump version, build changelog, publish to npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: "!contains(github.event.head_commit.message, 'Release @policyengine/ui-kit')"
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+      - uses: actions/checkout@v6
 
       - name: Check for changelog fragments
         id: check
-        run: |
-          FRAGMENTS=$(ls changelog.d/ | grep -v .gitkeep | wc -l)
-          echo "count=$FRAGMENTS" >> "$GITHUB_OUTPUT"
+        run: .github/check_fragments.sh
 
       - name: Bump version
         if: steps.check.outputs.count != '0'
@@ -56,11 +54,4 @@ jobs:
 
       - name: Commit and push
         if: steps.check.outputs.count != '0'
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: "Release @policyengine/ui-kit"
-          default_author: github_actions
-          add: |
-            package.json
-            CHANGELOG.md
-            changelog.d/
+        run: .github/commit_and_push.sh

--- a/changelog.d/fix-ci.fixed.md
+++ b/changelog.d/fix-ci.fixed.md
@@ -1,0 +1,1 @@
+Fix CI/CD workflow: drop expired PAT, use default GITHUB_TOKEN, extract scripts


### PR DESCRIPTION
Fixes #5

## Summary
- Drop expired `POLICYENGINE_GITHUB` PAT from `actions/checkout`; use default `GITHUB_TOKEN` with `permissions: contents: write`
- Bump `actions/checkout` from v4 to v6
- Replace `EndBug/add-and-commit@v9` with `.github/commit_and_push.sh`
- Extract inline fragment check into `.github/check_fragments.sh`

## Test plan
- [ ] Merge this PR and verify the push.yml workflow succeeds on main
- [ ] Confirm changelog fragments are consumed and version is bumped
- [ ] Confirm npm publish step runs (requires `NPM_TOKEN` secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)