### PR TITLE
Add --access public to npm publish

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.check.outputs.count != '0'
-        run: npm publish
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/changelog.d/npm-access.fixed.md
+++ b/changelog.d/npm-access.fixed.md
@@ -1,0 +1,1 @@
+Add --access public to npm publish for scoped package


### PR DESCRIPTION
Fixes #7

## Summary
- Add `--access public` flag to `npm publish` in CI workflow for scoped package first publish

## Test plan
- [ ] Verified locally with `npm publish --access public --dry-run` — passes
- [ ] Merge and confirm CI publishes `@policyengine/ui-kit` to npm successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)