### PR TITLE
Make demo site Vercel-deployable

### DIFF
--- a/changelog.d/vercel-demo.added.md
+++ b/changelog.d/vercel-demo.added.md
@@ -1,0 +1,1 @@
+Make demo site deployable to Vercel

--- a/vite.demo.config.ts
+++ b/vite.demo.config.ts
@@ -5,12 +5,17 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
+  root: 'demo',
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),
     },
   },
+  build: {
+    outDir: resolve(__dirname, 'demo-dist'),
+    emptyOutDir: true,
+  },
   server: {
-    open: '/demo/index.html',
+    open: true,
   },
 });


### PR DESCRIPTION
Fixes #9

## Summary
- Set `root: 'demo'` in `vite.demo.config.ts` so Vite finds `index.html`
- Set `build.outDir` to `demo-dist/` to avoid conflicting with library `dist/`
- Dev server and production build both verified locally

## Vercel settings
- **Build command:** `vite build --config vite.demo.config.ts`
- **Output directory:** `demo-dist`

## Test plan
- [ ] `bun run dev:demo` still works locally
- [ ] `npx vite build --config vite.demo.config.ts` produces `demo-dist/` with working HTML
- [ ] Deploy to Vercel with the settings above

🤖 Generated with [Claude Code](https://claude.com/claude-code)