### PR TITLE
Fix demo site styling on Vercel

### DIFF
--- a/changelog.d/fix-demo-source.fixed.md
+++ b/changelog.d/fix-demo-source.fixed.md
@@ -1,0 +1,1 @@
+Fix demo site styling on Vercel by scanning source components for Tailwind classes

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -1,2 +1,5 @@
 @import "tailwindcss";
 @import "../src/theme/tokens.css";
+
+/* Scan source components so Tailwind generates utility classes for them */
+@source "../src/**/*.{ts,tsx}";


### PR DESCRIPTION
Fixes #11

## Summary
- Add `@source "../src/**/*.{ts,tsx}"` to `demo.css` so Tailwind scans source components directly
- The existing `@source` in `tokens.css` points to `dist/` which only exists after a library build, not on Vercel

## Test plan
- [ ] `bun run dev:demo` still renders correctly locally
- [ ] `npx vite build --config vite.demo.config.ts` produces 67KB+ CSS (not 3.5KB)
- [ ] Vercel deploy at https://policyengine-ui-kit.vercel.app/ shows styled components

🤖 Generated with [Claude Code](https://claude.com/claude-code)