### PR TITLE
Trigger 0.4.0 npm publish

### DIFF
--- a/changelog.d/publish-040.added.md
+++ b/changelog.d/publish-040.added.md
@@ -1,0 +1,1 @@
+Publish 0.4.0 to npm — includes Header with nav/country selector/mobile menu, Footer, visualization components, impact charts, and all fixes since 0.3.1


### PR DESCRIPTION
Adds a changelog fragment to trigger the automated version bump + npm publish.

The 0.4.0 changelog entry was added on 2026-03-23 but the fragments were consumed in the same commit, so the publish workflow never triggered. npm still has 0.3.1 from 2026-03-17.

This fragment triggers the workflow to:
1. Bump `package.json` from 0.3.1 → 0.4.0 (`.added.md` → minor bump)
2. Build the dist
3. Publish to npm

All code for 0.4.0 is already on main — this PR just adds the trigger file.