### PR TITLE
Fix publish pipeline: replace towncrier check with direct fragment detection

### DIFF
--- a/.github/check_pr_fragment.sh
+++ b/.github/check_pr_fragment.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FRAGMENTS=$(find changelog.d/ -type f ! -name '.gitkeep' | wc -l | tr -d ' ')
+
+if [ "$FRAGMENTS" -eq 0 ]; then
+  echo "::error::No changelog fragment found in changelog.d/."
+  echo "Add a fragment: echo 'Your change description' > changelog.d/<name>.<type>.md"
+  echo "Valid types: added, changed, fixed, removed, breaking"
+  exit 1
+fi
+
+echo "Found $FRAGMENTS changelog fragment(s)."

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,23 +7,11 @@ jobs:
   changelog:
     name: Changelog fragment
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install towncrier
-        run: pip install towncrier
-
       - name: Check for changelog fragment
-        run: towncrier check --compare-with origin/main
+        run: .github/check_pr_fragment.sh
 
   test:
     name: Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,5 @@
 # Changelog
 
-## [0.4.0] - 2026-03-23
-
-### Added
-
-- US congressional district choropleth map (d3-geo) with geographic and hexagonal views, zoom/pan, tooltips, and SVG download
-- UK constituency choropleth map with geographic and hexagonal views
-- State legislative district map for senate (29 states) and house (8 states) districts using Census 2024 Cartographic Boundary Files
-- Generic hexagonal tile map component
-- Household composition graph visualization
-- Impact chart suite: decile bar chart, winners/losers, earnings comparison, budget waterfall
-- Map UI controls: MapTypeToggle, ZoomControls, MapDownloadButton
-- Diverging color scales (gray-teal, gray-blue) and semantic color mappings
-- Chart utilities: tick calculation, axis width estimation, waterfall computation
-- Expanded formatter suite (currency, percent, compact numbers)
-- Chart loading/error/empty state messages
-- SelectInput chevron caret that rotates on open/close
-- Data adapters for constituency and local authority data transformation
-- Bundled GeoJSON data for US congressional districts, UK constituencies, and state legislative districts
-
-### Changed
-
-- Align gray palette with app-v2 gray scale (gray-50 through gray-900)
-- Darken muted-foreground from gray-500 to gray-600 for accessibility
-- Refactor waterfall chart with connector lines and extracted utilities
-- Double PolicyEngineWatermark width across all map components
-- Rename homeHeader to header with consolidated component names
-- Add d3-geo as dependency
-- Dynamic y-axis layout with auto-width calculation in ChartContainer
-
-### Fixed
-
-- Primitive focus ring and border color consistency (Accordion, Checkbox, Command, Input, RadioGroup, ScrollArea, Select, Spinner, Text, Textarea)
-- Light gray text colors darkened for WCAG contrast
-
 ## [0.3.1] - 2026-03-17
 
 ### Fixed
@@ -63,7 +29,6 @@
 
 
 
-[0.4.0]: https://github.com/PolicyEngine/policyengine-ui-kit/compare/0.3.1...0.4.0
 [0.3.1]: https://github.com/PolicyEngine/policyengine-ui-kit/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/PolicyEngine/policyengine-ui-kit/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/PolicyEngine/policyengine-ui-kit/compare/0.0.0...0.2.0

--- a/changelog.d/fix-fragment-check.fixed.md
+++ b/changelog.d/fix-fragment-check.fixed.md
@@ -1,0 +1,1 @@
+Replace towncrier check with custom fragment detection script to fix publish pipeline bypass


### PR DESCRIPTION
## Summary

- Replace `towncrier check` in the PR workflow with a custom shell script (`.github/check_pr_fragment.sh`) that directly counts files in `changelog.d/`
- Removes the towncrier bypass loophole where modifying `CHANGELOG.md` auto-skips fragment enforcement
- Eliminates Python/towncrier dependency from PR checks (faster CI — 2 steps instead of 4)
- Reverts the manually-written 0.4.0 `CHANGELOG.md` section so `build_changelog.py` generates it cleanly from fragments

Closes #16

## Context

`towncrier check --compare-with origin/main` has a documented behavior: it auto-skips fragment enforcement when the news file (`CHANGELOG.md`) is modified in the branch. This is intended for release branches but creates a loophole — PR #14 merged without a fragment, so the push-to-main publish workflow never triggered (it keys off fragment count). npm stayed at 0.3.1.

## Test plan

- [ ] PR check passes with the fragment included in this PR
- [ ] Verify a PR without a fragment would fail the new check (remove fragment locally and test)
- [ ] After merge, push workflow detects fragments and triggers version bump + publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)