### PR TITLE
Fix light-mode --text-tertiary WCAG AA contrast

### DIFF
--- a/changelog.d/text-tertiary-contrast.fixed.md
+++ b/changelog.d/text-tertiary-contrast.fixed.md
@@ -1,0 +1,1 @@
+- Darken light-mode `--text-tertiary` from `#94A3B8` (~2.6:1 on white, failing WCAG AA) to `#64748B` (gray-500, 4.5:1+), so tertiary/muted text is accessible by default and consumers no longer need per-app overrides. Dark mode is unchanged (`#94A3B8` is 7.5:1 on the dark background).

--- a/src/theme/tokens.css
+++ b/src/theme/tokens.css
@@ -79,7 +79,7 @@
   /* Text semantic aliases */
   --text-primary: #000000;
   --text-secondary: #5a5a5a;
-  --text-tertiary: #94A3B8;
+  --text-tertiary: #64748B;
   --text-inverse: #ffffff;
 
   /* Accessible-on-white text variants. Distinct from --color-warning / --color-error / --color-success fill values, which are tuned for badges and status dots and do not always clear WCAG AA when used as text. */

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -132,7 +132,11 @@ const lightSections: CssSection[] = [
     declarations: {
       "--text-primary": "#000000",
       "--text-secondary": "#5a5a5a",
-      "--text-tertiary": "#94A3B8",
+      // gray-500: meets WCAG AA (4.5:1) as normal text on white and on
+      // --background-secondary. The prior #94A3B8 was ~2.6:1 and failed,
+      // forcing consumers to override muted text per app. Dark mode (below)
+      // keeps #94A3B8, which is 7.5:1 on the dark background.
+      "--text-tertiary": "#64748B",
       "--text-inverse": "#ffffff",
     },
   },


### PR DESCRIPTION
## What

Light-mode `--text-tertiary` was `#94A3B8`, which is **~2.6:1 on white** — well under the WCAG AA threshold (4.5:1) for normal text. As a result, consumer apps have been overriding muted/tertiary text per app (e.g. PolicyBench remaps it to gray-600) instead of trusting the token.

This darkens light-mode `--text-tertiary` to `#64748B` (the existing **gray-500** brand token):

| Context | Before (`#94A3B8`) | After (`#64748B`) |
| --- | --- | --- |
| on `#FFFFFF` (`--background`) | 2.56:1 ❌ | 4.76:1 ✅ |
| on `#f5f9ff` (`--background-secondary`) | 2.43:1 ❌ | 4.50:1 ✅ |

It stays lighter than `--text-secondary` (`#5a5a5a`, 6.9:1) so the primary → secondary → tertiary hierarchy holds, and keeps the same slate hue.

**Dark mode is unchanged** — `#94A3B8` is 7.5:1 on the `#0B0E14` background and already passes.

## How

Edited the source of truth `src/theme/tokens.ts` (with a rationale comment) and regenerated `src/theme/tokens.css` via `bun run generate-tokens`. Added a towncrier `fixed` fragment.

## Verification

- `bun run test` → 300 passed, 2 skipped (incl. the generated-CSS parity test)
- `bun run build` → success
- `bun run typecheck` → clean

## Follow-up

Consumers that hand-rolled an accessible muted-text override (PolicyBench) can drop it once they bump to the release that includes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
